### PR TITLE
Update Black to 22.0.3 to fix build

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 bandit==1.7.0
-black==21.9b0
+black==22.3.0
 build>=0.7.0
 coverage[toml]==6.0.2
 flake8==4.0.1


### PR DESCRIPTION
The Black version had lagged to one that would not build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/juledwar/db-testtools/4)
<!-- Reviewable:end -->
