### PR TITLE
Improve uniqueness of PostgreSQL container names

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,11 +13,6 @@ setenv =
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 
-whitelist_externals =
-    bash
-    echo
-    mkdir
-
 commands =
     repl: ipython {posargs}
     pep8: flake8 dbtesttools {posargs}
@@ -53,7 +48,11 @@ exclude =
     .eggs
 show-source = true
 ignore =
-    D10  # ignore missing docstrings (for now)
-    D202  # No blank lines allowed after function docstring (caused by Black)
-    E203  # Whitespace before ':' (caused by Black)
-    W503  # line breaks after operators (caused by Black)
+    # ignore missing docstrings (for now)
+    D10
+    # No blank lines allowed after function docstring (caused by Black)
+    D202
+    # Whitespace before ':' (caused by Black)
+    E203
+    # line breaks after operators (caused by Black)
+    W503


### PR DESCRIPTION
Base PostgreSQL container names on the PID of the running process, to keep collisions to a minimum.

Drive-by: remove a bunch of `allowlist_externals` that were unused by anything, and update `tox.ini` to work with modern vintages of `tox`.

Fixes: Issue #5

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/juledwar/db-testtools/6)
<!-- Reviewable:end -->
